### PR TITLE
feat: define new tag from a batch of commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ version INFO: Current version is: v0.0.4
 version INFO: New tag will be created and pushed. Tag: v0.0.5, message Automatically created tag
 ```
 
+To create new tag from the bunch of commits, e.g. in case of merge not squashed merge request, use `--start_from` option.
+It allows to parse all commits from the specified version to current HEAD and select the highest increment, based on
+commit messages. Be aware, that only current HEAD are not allowed to contain a tag!
+
+See your CI preferences to obtain a commit before your merge.
+
 ### See or change the configuration
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
     name = "tag_creator"
-    version = "v0.0.5"
+    version = "v0.1.0"
     keywords = ["git", "tag", "create git tag", "git release tag", "semver tag"]
     authors = [
         { name="Vladyslav Honcharenko", email="goncharvlad02@gmail.com" }

--- a/tag_creator/__main__.py
+++ b/tag_creator/__main__.py
@@ -2,13 +2,15 @@ import yaml
 from tag_creator.repository.version import ProjectVersionUpdater
 from tag_creator.logger import logger
 from tag_creator import configuration as cfg
-from tag_creator.arguments import args
+from tag_creator.arguments import parse
 
 
 if __name__ == "__main__":
 
+    args = parse()
+
     if args.show_config:
-        logger.info(yaml.dump(cfg.read_configuration()))
+        logger.info(yaml.dump(cfg.read_configuration(args.custom_config_path)))
 
     pvu = ProjectVersionUpdater(
         repo_dir=args.repo_dir,
@@ -17,8 +19,11 @@ if __name__ == "__main__":
         dry_run=args.dry_run
     )
 
-    if args.create_new_tag:
-        pvu.create_new_verion()
+    if args.create_new_tag and args.start_from:
+        pvu.new_versions_from_batch(args.start_from)
+
+    if args.create_new_tag and not args.start_from:
+        pvu.create_new_version()
 
     if args.current_version:
         logger.info(f"Current tag: {pvu.current_tag()} Branch: {args.release_branch}")

--- a/tag_creator/arguments.py
+++ b/tag_creator/arguments.py
@@ -7,6 +7,15 @@ def parse() -> argparse.Namespace:
     parser.add_argument("--release_branch",
                         help="Release branch. (default: %(default)s)", required=False, default="main")
     parser.add_argument("--create_new_tag", help="Update tag", action="store_true", default=False)
+    parser.add_argument(
+        "--start_from",
+        help=(
+            "Find the new value starting from the given commit."
+            "The highest increment present in the commits will be selected."
+        ),
+        required=False,
+        default=""
+    )
     parser.add_argument("--dry_run", help="Do not update remote", action="store_true", default=False)
     parser.add_argument("--show_config", help="Show default config", action="store_true", default=False)
     parser.add_argument("--config", help="Config file", required=False, default="")
@@ -15,6 +24,3 @@ def parse() -> argparse.Namespace:
                         required=False, default="")
 
     return parser.parse_args()
-
-
-args = parse()

--- a/tag_creator/configuration.py
+++ b/tag_creator/configuration.py
@@ -1,24 +1,23 @@
 import yaml
 import os
 from typing import Dict, List, Any
-from tag_creator.arguments import args
 from tag_creator.logger import logger
 
 CONFIGURATION: Dict[str, str] = {}
 
 
-def read_configuration() -> Dict[str, Any]:
+def read_configuration(custom_config_path: str = "") -> Dict[str, Any]:
     global CONFIGURATION
     if not CONFIGURATION:
         with open(f"{os.path.dirname(__file__)}/configuration.yml", "r") as f:
             CONFIGURATION = yaml.safe_load(f)
-            CONFIGURATION.update(custom_config())
+            CONFIGURATION.update(custom_config(custom_config_path))
     return CONFIGURATION
 
 
-def custom_config() -> Dict[str, Any]:
-    if os.path.exists(os.path.abspath(args.config)) and args.config:
-        with open(args.config, "r") as f:
+def custom_config(custom_config_path: str = "") -> Dict[str, Any]:
+    if os.path.exists(os.path.abspath(custom_config_path)) and custom_config_path:
+        with open(custom_config_path, "r") as f:
             logger.info("Custom config read!")
             return dict(yaml.safe_load(f))
     return {}


### PR DESCRIPTION
## Description

- new tag can be created from a batch of commits. E.g. $reference..HEAD
- fix argument parsing